### PR TITLE
Display leader board after set mode/ type

### DIFF
--- a/Assets/_Scripts/Menus/LeaderboardMenu.cs
+++ b/Assets/_Scripts/Menus/LeaderboardMenu.cs
@@ -58,27 +58,27 @@ public class LeaderboardMenu : BaseMenu
 
         endless.onClick.AddListener(() => SetMode(Modes.Endless));
         endless.onClick.AddListener(() => AdjustListener(endless, beatTheClock, delay));
-        endless.onClick.AddListener(() => DisplayLeaderboard());
+        //endless.onClick.AddListener(() => DisplayLeaderboard());
 
         beatTheClock.onClick.AddListener(() => SetMode(Modes.BeatTheClock));
         beatTheClock.onClick.AddListener(() => AdjustListener(beatTheClock, endless, delay));
-        beatTheClock.onClick.AddListener(() => DisplayLeaderboard());
+        //beatTheClock.onClick.AddListener(() => DisplayLeaderboard());
 
         delay.onClick.AddListener(() => SetMode(Modes.Delay));
         delay.onClick.AddListener(() => AdjustListener(delay, beatTheClock, endless));
-        delay.onClick.AddListener(() => DisplayLeaderboard());
+        //delay.onClick.AddListener(() => DisplayLeaderboard());
 
         threeXThree.onClick.AddListener(() => SetType(Types.ThreeXThree));
         threeXThree.onClick.AddListener(() => AdjustListener(threeXThree, fourXFour, fiveXFive));
-        threeXThree.onClick.AddListener(() => DisplayLeaderboard());
+        //threeXThree.onClick.AddListener(() => DisplayLeaderboard());
 
         fourXFour.onClick.AddListener(() => SetType(Types.FourXFour));
         fourXFour.onClick.AddListener(() => AdjustListener(fourXFour, threeXThree, fiveXFive));
-        fourXFour.onClick.AddListener(() => DisplayLeaderboard());
+        //fourXFour.onClick.AddListener(() => DisplayLeaderboard());
 
         fiveXFive.onClick.AddListener(() => SetType(Types.FiveXFive));
         fiveXFive.onClick.AddListener(() => AdjustListener(fiveXFive, fourXFour, threeXThree));
-        fiveXFive.onClick.AddListener(() => DisplayLeaderboard());               
+        //fiveXFive.onClick.AddListener(() => DisplayLeaderboard());               
     }      
 
     public override void EnterState()
@@ -285,12 +285,14 @@ public class LeaderboardMenu : BaseMenu
 
     private void SetMode(Modes mode)
     {
-        currentMode = mode;       
+        currentMode = mode;
+        DisplayLeaderboard();
     }
 
     void SetType(Types type)
     {
         currentType = type;
+        DisplayLeaderboard();
     }
 
     void AdjustListener(Button a, Button b, Button c)


### PR DESCRIPTION
Hopefully fixed a bug where one of the leaderboard buttons wasn't working properly. 
I moved the display function into the set mode/ type function so it now always displays after the mode/ type has been set, this should make sure the order of events is correct. 